### PR TITLE
Improve housing and general bg handling

### DIFF
--- a/Meddle/Meddle.Plugin/Configuration.cs
+++ b/Meddle/Meddle.Plugin/Configuration.cs
@@ -28,6 +28,7 @@ public partial class Configuration : IPluginConfiguration
     public bool DisableCutsceneUiHide { get; set; } = true;
     public bool DisableGposeUiHide { get; set; } = true;
     public string ExportDirectory { get; set; } = Plugin.DefaultExportDirectory;
+    public string SecretConfig { get; set; } = string.Empty;
     
     /// <summary>
     /// Used to hide names in the UI

--- a/Meddle/Meddle.Plugin/Models/Layout/ParsedInstance.cs
+++ b/Meddle/Meddle.Plugin/Models/Layout/ParsedInstance.cs
@@ -265,18 +265,20 @@ public class ParsedBgPartsInstance : ParsedInstance, IPathInstance, IStainableIn
 {
     public bool IsVisible { get; }
     public HandleString Path { get; }
+    public (int BGChangeMaterialIndex, string MaterialPath)? BgChangeMaterial { get; }
 
-    public ParsedBgPartsInstance(nint id, bool isVisible, Transform transform, string path) : base(id, ParsedInstanceType.BgPart, transform)
+    public ParsedBgPartsInstance(nint id, bool isVisible, Transform transform, string path, (int BGChangeMaterialIndex, string MaterialPath)? bgChangeMaterial) : base(id, ParsedInstanceType.BgPart, transform)
     {
         IsVisible = isVisible;
         Path = path;
+        BgChangeMaterial = bgChangeMaterial;
     }
 
     public ParsedStain? Stain { get; set; }
 
     public bool Search(string query)
     {
-        return Path.FullPath.Contains(query, StringComparison.OrdinalIgnoreCase) || 
+        return Path.FullPath.Contains(query, StringComparison.OrdinalIgnoreCase) ||
                Path.GamePath.Contains(query, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/Meddle/Meddle.Plugin/Models/Structs/BgObject.cs
+++ b/Meddle/Meddle.Plugin/Models/Structs/BgObject.cs
@@ -1,0 +1,50 @@
+﻿using System.Runtime.InteropServices;
+using FFXIVClientStructs.FFXIV.Client.System.Resource.Handle;
+using FFXIVClientStructs.Interop;
+
+namespace Meddle.Plugin.Models.Structs;
+
+[StructLayout(LayoutKind.Explicit, Size = 0xD0)]
+public unsafe struct BgObject
+{
+    [FieldOffset(0x00)] public FFXIVClientStructs.FFXIV.Client.Graphics.Scene.BgObject Base;
+    [FieldOffset(0x90)] public ModelResourceHandle* ModelResourceHandle;
+    [FieldOffset(0xA8)] public BgObjectAdditionalData* BGChangeData;
+    
+    public ModelResourceHandleData GetModelResourceHandleData()
+    {
+        if (ModelResourceHandle == null)
+            return default;
+        
+        return new ModelResourceHandleData(ModelResourceHandle->ModelData);
+    }
+    public (int MaterialIndex, Pointer<MaterialResourceHandle> ResourceHandle)? GetBgChangeMaterial()
+    {
+        if (BGChangeData == null || ModelResourceHandle == null)
+            return null;
+        
+        var modelData = GetModelResourceHandleData();
+        if (modelData.ModelHeader.MaterialCount == 0)
+            return null;
+        
+        var flags3Value = modelData.ModelHeader.Flags3;
+        if ((flags3Value & 0x2) != 0 & modelData.ModelHeader.BGChangeMaterialIndex < modelData.ModelHeader.MaterialCount)
+        {
+            if (BGChangeData->MaterialResourceHandle == null)
+            {
+                return null;
+            }
+
+            Pointer<MaterialResourceHandle> handle = BGChangeData->MaterialResourceHandle;
+            return (modelData.ModelHeader.BGChangeMaterialIndex, handle);
+        }
+        
+        return null;
+    }
+}
+
+[StructLayout(LayoutKind.Explicit, Size = 0x38)]
+public unsafe struct BgObjectAdditionalData
+{
+    [FieldOffset(0x18)] public MaterialResourceHandle* MaterialResourceHandle;
+}

--- a/Meddle/Meddle.Plugin/Models/Structs/BgObject.cs
+++ b/Meddle/Meddle.Plugin/Models/Structs/BgObject.cs
@@ -28,7 +28,7 @@ public unsafe struct BgObject
             return null;
         
         var flags3Value = modelData.ModelHeader.Flags3;
-        if ((flags3Value & 0x2) != 0 & modelData.ModelHeader.BGChangeMaterialIndex < modelData.ModelHeader.MaterialCount)
+        if ((flags3Value & 0x2) != 0 && modelData.ModelHeader.BGChangeMaterialIndex < modelData.ModelHeader.MaterialCount)
         {
             if (BGChangeData->MaterialResourceHandle == null)
             {

--- a/Meddle/Meddle.Plugin/Models/Structs/ModelResourceHandle.cs
+++ b/Meddle/Meddle.Plugin/Models/Structs/ModelResourceHandle.cs
@@ -1,8 +1,18 @@
-﻿using FFXIVClientStructs.Interop;
+﻿using System.Runtime.InteropServices;
+using FFXIVClientStructs.Interop;
 using Meddle.Plugin.Utils;
 using Meddle.Utils.Files.Structs.Model;
 
 namespace Meddle.Plugin.Models.Structs;
+
+[StructLayout(LayoutKind.Explicit, Size = 0x2A0)]
+public unsafe struct MeddleModelResourceHandle
+{
+    [FieldOffset(0x0)] public FFXIVClientStructs.FFXIV.Client.System.Resource.Handle.ModelResourceHandle* Base;
+    [FieldOffset(0xC8)] public byte* ModelData; // StringTable, ModelHeader ...
+    public ModelResourceHandleData GetData() => new(Base->ModelData);
+} 
+
 
 public readonly struct ModelResourceHandleData
 {
@@ -11,12 +21,12 @@ public readonly struct ModelResourceHandleData
     public readonly byte[] StringTableData;
     public readonly ModelHeader ModelHeader;
         
-    public ModelResourceHandleData(Pointer<byte> stringTablePtr)
+    public ModelResourceHandleData(Pointer<byte> modelDataPtr)
     {
         var offset = 0;
-        StringCount = stringTablePtr.Read<uint>(ref offset);
-        StringTableSize = stringTablePtr.Read<uint>(ref offset);
-        StringTableData = stringTablePtr.ReadSpan<byte>((int)StringTableSize, ref offset).ToArray();
-        ModelHeader = stringTablePtr.Read<ModelHeader>(ref offset);
+        StringCount = modelDataPtr.Read<uint>(ref offset);
+        StringTableSize = modelDataPtr.Read<uint>(ref offset);
+        StringTableData = modelDataPtr.ReadSpan<byte>((int)StringTableSize, ref offset).ToArray();
+        ModelHeader = modelDataPtr.Read<ModelHeader>(ref offset);
     }
 } 

--- a/Meddle/Meddle.Plugin/UI/DebugTab.cs
+++ b/Meddle/Meddle.Plugin/UI/DebugTab.cs
@@ -122,6 +122,13 @@ public class DebugTab : ITab
         {
             var cofigJson = JsonSerializer.Serialize(config, jsonOptions);
             ImGui.TextWrapped(cofigJson);
+
+            var secretConfigOption = config.SecretConfig;
+            if (ImGui.InputText("Secret Config", ref secretConfigOption, 50))
+            {
+                config.SecretConfig = secretConfigOption;
+                config.Save();
+            }
         }
 
         if (ImGui.CollapsingHeader("EnvLighting"))
@@ -347,7 +354,7 @@ public class DebugTab : ITab
                 var configClone = config.ExportConfig.Clone();
                 var pathFileName = Path.GetFileNameWithoutExtension(exportPathInput);
                 var defaultName = $"Export-{pathFileName}-{DateTime.Now:yyyy-MM-dd-HH-mm-ss}";
-                var stubInstance = new ParsedBgPartsInstance(0, true, new Transform(AffineTransform.Identity), exportPathInput);
+                var stubInstance = new ParsedBgPartsInstance(0, true, new Transform(AffineTransform.Identity), exportPathInput, null);
                 fileDialog.SaveFolderDialog("Save Instances", defaultName,
                                             (result, exportPath) =>
                                             {

--- a/Meddle/Meddle.Plugin/UI/Layout/Instance.cs
+++ b/Meddle/Meddle.Plugin/UI/Layout/Instance.cs
@@ -31,6 +31,9 @@ public partial class LayoutWindow
     
     private unsafe void DrawControlsEvil(ParsedInstance instance)
     {
+        // validate instance still exists
+        if (currentLayout.All(i => i.Id != instance.Id)) return;
+        
         var layoutInstance = (ILayoutInstance*)instance.Id;
         var graphics = layoutInstance->GetGraphics();
         if (graphics == null) return;
@@ -88,8 +91,12 @@ public partial class LayoutWindow
             ImGui.Text($"Position: {instance.Transform.Translation}");
             ImGui.Text($"Rotation: {instance.Transform.Rotation}");
             ImGui.Text($"Scale: {instance.Transform.Scale}");
-            // DrawControlsEvil(instance);
-            
+
+            if (config.SecretConfig == "Kweh")
+            {
+                DrawControlsEvil(instance);
+            }
+
             if (instance is IPathInstance pathedInstance)
             {
                 UiUtil.Text($"Full Path: {pathedInstance.Path.FullPath}", pathedInstance.Path.FullPath);
@@ -194,6 +201,11 @@ public partial class LayoutWindow
         {
             BgObject* drawObject = bgPartLayout->GraphicsObject;
             UiUtil.Text($"Graphics Object {(nint)drawObject:X8}", $"{(nint)drawObject:X8}");
+            if (bg.BgChangeMaterial != null)
+            {
+                ImGui.Text($"BgChangeMaterialPath: {bg.BgChangeMaterial.Value.MaterialPath}");
+            }
+            
             using var disabled = ImRaii.Disabled( mdlMaterialWindowManager.HasWindow(drawObject->ModelResourceHandle));
             if (ImGui.Button("Open Material Window"))
             {

--- a/Meddle/Meddle.Plugin/UI/Layout/LayoutWindow.cs
+++ b/Meddle/Meddle.Plugin/UI/Layout/LayoutWindow.cs
@@ -411,6 +411,10 @@ public partial class LayoutWindow : ITab
             {
                 flags |= UiUtil.ExportConfigDrawFlags.ShowBgPartOptions;
             }
+            else if (instances.Any(t => t is ParsedSharedInstance sh && sh.Flatten().Any(i => i is ParsedBgPartsInstance { IsVisible: false })))
+            {
+                flags |= UiUtil.ExportConfigDrawFlags.ShowBgPartOptions;
+            }
             if (instances.Any(t => (t.Type & ParsedInstanceType.Terrain) != 0))
             {
                 flags |= UiUtil.ExportConfigDrawFlags.ShowTerrainOptions;

--- a/Meddle/Meddle.Plugin/UI/Layout/Overlay.cs
+++ b/Meddle/Meddle.Plugin/UI/Layout/Overlay.cs
@@ -1,5 +1,6 @@
 ﻿using System.Numerics;
 using Dalamud.Interface.Utility.Raii;
+using FFXIVClientStructs.FFXIV.Client.LayoutEngine;
 using ImGuiNET;
 using Meddle.Plugin.Models.Layout;
 using Meddle.Plugin.Models.Structs;
@@ -188,6 +189,16 @@ public partial class LayoutWindow
         {
             if (!searchable.Search(search))
                 return InstanceSelectState.None;
+        }
+
+        if (parent != null)
+        {
+            if (parent is ParsedHousingInstance hi)
+            {
+                // if housing not in flags, ignore
+                if (!config.LayoutConfig.DrawTypes.HasFlag(ParsedInstanceType.Housing))
+                    return InstanceSelectState.None;
+            }
         }
 
         if (obj is ParsedSharedInstance sharedInstance)

--- a/Meddle/Meddle.Plugin/UI/Windows/UpdateWindow.cs
+++ b/Meddle/Meddle.Plugin/UI/Windows/UpdateWindow.cs
@@ -36,8 +36,8 @@ public class UpdateWindow : Window
         },
         new()
         {
-            Tag = "Decal Support and MultiTrack recording",
-            Date = "2025-07-22",
+            Tag = "Decal Support, MultiTrack recording and Housing Improvements",
+            Date = "2025-07-27",
             Changes =
             [
                 new TextUpdateLine(" + Added support for exporting decal textures for characters"),
@@ -48,6 +48,9 @@ public class UpdateWindow : Window
                 new TextUpdateLine(" + Added support for exporting environment ambient, sun and moon lighting from layout tab"),
                 new TextUpdateLine(" + Added option to include shared groups when only a subset of the group is within range in the layout tab"),
                 new TextUpdateLine(" + Added support for many missed texture types which are less frequently used but still supported by the game"),
+                new TextUpdateLine(" + Fixed issues with staining on certain housing items"),
+                new TextUpdateLine(" + Added support for BGChange objects (housing wall and floor customization) exports"),
+                new TextUpdateLine(" + Exported housing objects should now be named after their in-game names instead of their paths"),
             ]
         }
     ];

--- a/Meddle/Meddle.Utils/Files/Structs/Model/Model.cs
+++ b/Meddle/Meddle.Utils/Files/Structs/Model/Model.cs
@@ -233,30 +233,30 @@ public unsafe struct VertexDeclaration {
 
 [StructLayout(LayoutKind.Sequential, Size = 56)]
 public struct ModelHeader {
-    public float Radius;
-    public ushort MeshCount;
-    public ushort AttributeCount;
-    public ushort SubmeshCount;
-    public ushort MaterialCount;
-    public ushort BoneCount;
-    public ushort BoneTableCount;
-    public ushort ShapeCount;
-    public ushort ShapeMeshCount;
-    public ushort ShapeValueCount;
-    public byte LodCount;
-    public byte Flags1;
-    public ushort ElementIdCount;
-    public byte TerrainShadowMeshCount;
-    public byte Flags2;
-    public float ModelClipOutDistance;
-    public float ShadowClipOutDistance;
-    public ushort Unknown4;
-    public ushort TerrainShadowSubmeshCount;
-    public byte Unknown5;
-    public byte BGChangeMaterialIndex;
-    public byte BGCrestChangeMaterialIndex;
-    public byte Unknown6;
-    public ushort BoneTableArrayCountTotal;
-    public ushort Unknown8;
-    public ushort Unknown9;
+    public float Radius; // 0x0
+    public ushort MeshCount; // 0x4
+    public ushort AttributeCount; // 0x6
+    public ushort SubmeshCount; // 0x8
+    public ushort MaterialCount; // 0xA
+    public ushort BoneCount; // 0xC
+    public ushort BoneTableCount; // 0xE
+    public ushort ShapeCount; // 0x10
+    public ushort ShapeMeshCount; // 0x12
+    public ushort ShapeValueCount; // 0x14
+    public byte LodCount; // 0x16
+    public byte Flags1; // 0x17
+    public ushort ElementIdCount; // 0x18
+    public byte TerrainShadowMeshCount; // 0x1A
+    public byte Flags2; // 0x1B
+    public float ModelClipOutDistance; // 0x1C
+    public float ShadowClipOutDistance; // 0x20
+    public ushort Unknown4; // 0x24
+    public ushort TerrainShadowSubmeshCount; // 0x26
+    public byte Flags3; // 0x28
+    public byte BGChangeMaterialIndex; // 0x29
+    public byte BGCrestChangeMaterialIndex; // 0x2A
+    public byte Unknown6; // 0x2B
+    public ushort BoneTableArrayCountTotal; // 0x2C
+    public ushort Unknown8; // 0x2E
+    public ushort Unknown9; // 0x30
 }


### PR DESCRIPTION
- fix shared group children not triggering visibility of bgpart setting
- add parsing of live bgpart mtrl paths
- fix memory safety around layout parts that havent finished loading yet
- exported housing items should now be named
- add support for exporting bgchange instances properly by using the alternate mtrl lookup